### PR TITLE
In-App Validation Rules Support Screen

### DIFF
--- a/app/.gitignore
+++ b/app/.gitignore
@@ -1,1 +1,4 @@
 /build
+
+# Generated at build time by downloadSupportContent task
+src/main/assets/validation-rules.md

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,3 +1,5 @@
+import java.net.HttpURLConnection
+import java.net.URI
 import java.util.Properties
 
 plugins {
@@ -83,6 +85,56 @@ android {
     }
 }
 
+val supportContentUrl: String = project.findProperty(
+    "supportContentUrl"
+) as? String
+    ?: ("https://raw.githubusercontent.com/" +
+            "akvo/african-bamboo-dashboard/" +
+            "main/frontend/public/docs/validation-rules.md")
+
+tasks.register("downloadSupportContent") {
+    description = "Downloads validation rules markdown from the DCU repo"
+    val outputFile = file("src/main/assets/validation-rules.md")
+
+    doLast {
+        try {
+            val conn = URI(supportContentUrl).toURL()
+                .openConnection() as HttpURLConnection
+            conn.connectTimeout = 10_000
+            conn.readTimeout = 10_000
+            conn.inputStream.use { input ->
+                outputFile.outputStream().use { output ->
+                    input.copyTo(output)
+                }
+            }
+            logger.lifecycle(
+                "Downloaded support content to ${outputFile.path}"
+            )
+        } catch (e: Exception) {
+            if (outputFile.exists()) {
+                logger.warn(
+                    "Download failed, keeping existing: ${e.message}"
+                )
+            } else {
+                logger.warn(
+                    "Download failed, no fallback: ${e.message}"
+                )
+                outputFile.writeText(
+                    "# Validation Rules\n\n" +
+                            "Content unavailable. " +
+                            "Visit the project documentation."
+                )
+            }
+        }
+    }
+}
+
+tasks.matching {
+    it.name.startsWith("merge") && it.name.endsWith("Assets")
+}.configureEach {
+    dependsOn("downloadSupportContent")
+}
+
 dependencies {
     coreLibraryDesugaring(libs.desugar.jdk.libs)
     implementation(libs.androidx.core.ktx)
@@ -130,6 +182,9 @@ dependencies {
 
     // DataStore Preferences - runtime settings
     implementation(libs.datastore.preferences)
+
+    // Markdown-to-HTML converter for Support screen WebView
+    implementation(libs.jetbrains.markdown)
 
     // Security - Encrypted SharedPreferences
     implementation(libs.security.crypto)

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -85,32 +85,43 @@ android {
     }
 }
 
+val supportContentRef: String = project.findProperty(
+    "supportContentRef"
+) as? String ?: "main"
+
 val supportContentUrl: String = project.findProperty(
     "supportContentUrl"
 ) as? String
     ?: ("https://raw.githubusercontent.com/" +
             "akvo/african-bamboo-dashboard/" +
-            "main/frontend/public/docs/validation-rules.md")
+            "$supportContentRef/frontend/public/docs/validation-rules.md")
 
 tasks.register("downloadSupportContent") {
     description = "Downloads validation rules markdown from the DCU repo"
     val outputFile = file("src/main/assets/validation-rules.md")
 
+    inputs.property("supportContentUrl", supportContentUrl)
+    outputs.file(outputFile)
+
     doLast {
+        val tempFile = File(outputFile.parentFile, ".validation-rules.md.tmp")
         try {
+            outputFile.parentFile.mkdirs()
             val conn = URI(supportContentUrl).toURL()
                 .openConnection() as HttpURLConnection
             conn.connectTimeout = 10_000
             conn.readTimeout = 10_000
             conn.inputStream.use { input ->
-                outputFile.outputStream().use { output ->
+                tempFile.outputStream().use { output ->
                     input.copyTo(output)
                 }
             }
+            tempFile.renameTo(outputFile)
             logger.lifecycle(
                 "Downloaded support content to ${outputFile.path}"
             )
         } catch (e: Exception) {
+            tempFile.delete()
             if (outputFile.exists()) {
                 logger.warn(
                     "Download failed, keeping existing: ${e.message}"

--- a/app/src/main/java/org/akvo/afribamodkvalidator/navigation/AppNavHost.kt
+++ b/app/src/main/java/org/akvo/afribamodkvalidator/navigation/AppNavHost.kt
@@ -14,6 +14,7 @@ import org.akvo.afribamodkvalidator.ui.screen.GeoMapViewScreen
 import org.akvo.afribamodkvalidator.ui.screen.OfflineMapScreen
 import org.akvo.afribamodkvalidator.ui.screen.SettingsScreen
 import org.akvo.afribamodkvalidator.ui.screen.SubmissionDetailScreen
+import org.akvo.afribamodkvalidator.ui.screen.SupportScreen
 import org.akvo.afribamodkvalidator.ui.screen.SyncCompleteScreen
 
 @Composable
@@ -110,12 +111,21 @@ fun AppNavHost(
                 },
                 onSettingsClick = {
                     navController.navigate(Settings)
+                },
+                onSupportClick = {
+                    navController.navigate(Support)
                 }
             )
         }
 
         composable<Settings> {
             SettingsScreen(
+                onBack = { navController.popBackStack() }
+            )
+        }
+
+        composable<Support> {
+            SupportScreen(
                 onBack = { navController.popBackStack() }
             )
         }

--- a/app/src/main/java/org/akvo/afribamodkvalidator/navigation/Routes.kt
+++ b/app/src/main/java/org/akvo/afribamodkvalidator/navigation/Routes.kt
@@ -42,3 +42,6 @@ data class GeoMapView(val uuid: String, val fieldKey: String)
 
 @Serializable
 object Settings
+
+@Serializable
+object Support

--- a/app/src/main/java/org/akvo/afribamodkvalidator/ui/screen/HomeDashboardScreen.kt
+++ b/app/src/main/java/org/akvo/afribamodkvalidator/ui/screen/HomeDashboardScreen.kt
@@ -76,6 +76,7 @@ fun HomeDashboardScreen(
     onSubmissionClick: (String) -> Unit,
     onOfflineMapsClick: () -> Unit,
     onSettingsClick: () -> Unit,
+    onSupportClick: () -> Unit,
     modifier: Modifier = Modifier,
     viewModel: HomeViewModel = hiltViewModel(),
     updateViewModel: AppUpdateViewModel = hiltViewModel()
@@ -98,6 +99,7 @@ fun HomeDashboardScreen(
         onSubmissionClick = onSubmissionClick,
         onOfflineMapsClick = onOfflineMapsClick,
         onSettingsClick = onSettingsClick,
+        onSupportClick = onSupportClick,
         onSearchQueryChange = viewModel::onSearchQueryChange,
         onSearchActiveChange = viewModel::onSearchActiveChange,
         onSortOptionChange = viewModel::onSortOptionChange,
@@ -121,6 +123,7 @@ private fun HomeDashboardContent(
     onSubmissionClick: (String) -> Unit,
     onOfflineMapsClick: () -> Unit,
     onSettingsClick: () -> Unit,
+    onSupportClick: () -> Unit,
     onSearchQueryChange: (String) -> Unit,
     onSearchActiveChange: (Boolean) -> Unit,
     onSortOptionChange: (SortOption) -> Unit,
@@ -306,6 +309,14 @@ private fun HomeDashboardContent(
                                     onSettingsClick()
                                 }
                             )
+                            DropdownMenuItem(
+                                text = { Text("Support") },
+                                onClick = {
+                                    showMenu = false
+                                    onSupportClick()
+                                }
+                            )
+                            HorizontalDivider()
                             DropdownMenuItem(
                                 text = { Text("Logout") },
                                 onClick = {
@@ -495,6 +506,7 @@ private fun HomeDashboardPreview() {
             onSubmissionClick = {},
             onOfflineMapsClick = {},
             onSettingsClick = {},
+            onSupportClick = {},
             onSearchQueryChange = {},
             onSearchActiveChange = {},
             onSortOptionChange = {},
@@ -514,6 +526,7 @@ private fun HomeDashboardLoadingPreview() {
             onSubmissionClick = {},
             onOfflineMapsClick = {},
             onSettingsClick = {},
+            onSupportClick = {},
             onSearchQueryChange = {},
             onSearchActiveChange = {},
             onSortOptionChange = {},
@@ -538,6 +551,7 @@ private fun HomeDashboardSearchActivePreview() {
             onSubmissionClick = {},
             onOfflineMapsClick = {},
             onSettingsClick = {},
+            onSupportClick = {},
             onSearchQueryChange = {},
             onSearchActiveChange = {},
             onSortOptionChange = {},
@@ -560,6 +574,7 @@ private fun HomeDashboardEmptyPreview() {
             onSubmissionClick = {},
             onOfflineMapsClick = {},
             onSettingsClick = {},
+            onSupportClick = {},
             onSearchQueryChange = {},
             onSearchActiveChange = {},
             onSortOptionChange = {},

--- a/app/src/main/java/org/akvo/afribamodkvalidator/ui/screen/SupportScreen.kt
+++ b/app/src/main/java/org/akvo/afribamodkvalidator/ui/screen/SupportScreen.kt
@@ -1,0 +1,158 @@
+package org.akvo.afribamodkvalidator.ui.screen
+
+import android.content.Context
+import android.webkit.WebView
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.viewinterop.AndroidView
+import org.akvo.afribamodkvalidator.ui.theme.AfriBamODKValidatorTheme
+import org.intellij.markdown.flavours.gfm.GFMFlavourDescriptor
+import org.intellij.markdown.html.HtmlGenerator
+import org.intellij.markdown.parser.MarkdownParser
+
+private const val ASSET_FILE = "validation-rules.md"
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun SupportScreen(
+    onBack: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val context = LocalContext.current
+    val html = remember { buildHtml(context) }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Support") },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(
+                            imageVector =
+                                Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = "Back"
+                        )
+                    }
+                },
+                colors = TopAppBarDefaults.topAppBarColors(
+                    containerColor =
+                        MaterialTheme.colorScheme.surface,
+                    titleContentColor =
+                        MaterialTheme.colorScheme.onSurface
+                ),
+                windowInsets = WindowInsets(0)
+            )
+        },
+        modifier = modifier
+    ) { innerPadding ->
+        AndroidView(
+            factory = { ctx ->
+                WebView(ctx).apply {
+                    settings.javaScriptEnabled = false
+                    setBackgroundColor(0)
+                    loadDataWithBaseURL(
+                        null, html, "text/html", "UTF-8", null
+                    )
+                }
+            },
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(innerPadding)
+        )
+    }
+}
+
+private fun buildHtml(context: Context): String {
+    val markdown = loadMarkdownFromAssets(context)
+    val flavour = GFMFlavourDescriptor()
+    val tree = MarkdownParser(flavour).buildMarkdownTreeFromString(markdown)
+    val body = HtmlGenerator(markdown, tree, flavour).generateHtml()
+    return wrapWithStyle(body)
+}
+
+private fun wrapWithStyle(body: String): String = """
+<!DOCTYPE html>
+<html>
+<head>
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<style>
+  :root {
+    color-scheme: light dark;
+  }
+  body {
+    font-family: -apple-system, sans-serif;
+    font-size: 15px;
+    line-height: 1.5;
+    padding: 8px 12px;
+    margin: 0;
+    color: #1a1a1a;
+    background: transparent;
+  }
+  h1 { font-size: 1.4em; margin: 0.8em 0 0.4em; }
+  h2 { font-size: 1.25em; margin: 0.7em 0 0.3em; }
+  h3 { font-size: 1.1em; margin: 0.6em 0 0.3em; }
+  table {
+    width: 100%;
+    border-collapse: collapse;
+    margin: 0.8em 0;
+    font-size: 0.92em;
+  }
+  th, td {
+    border: 1px solid #ccc;
+    padding: 6px 8px;
+    text-align: left;
+  }
+  th {
+    background: #f0f0f0;
+    font-weight: 600;
+  }
+  tr:nth-child(even) { background: #f8f8f8; }
+  @media (prefers-color-scheme: dark) {
+    body { color: #e0e0e0; }
+    th { background: #2a2a2a; }
+    td { border-color: #444; }
+    tr:nth-child(even) { background: #1e1e1e; }
+    tr:nth-child(odd)  { background: transparent; }
+  }
+</style>
+</head>
+<body>
+$body
+</body>
+</html>
+""".trimIndent()
+
+private fun loadMarkdownFromAssets(context: Context): String {
+    return try {
+        context.assets
+            .open(ASSET_FILE)
+            .bufferedReader()
+            .use { it.readText() }
+    } catch (_: Exception) {
+        "# Validation Rules\n\nUnable to load content."
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun SupportScreenPreview() {
+    AfriBamODKValidatorTheme {
+        SupportScreen(onBack = {})
+    }
+}

--- a/app/src/main/java/org/akvo/afribamodkvalidator/ui/screen/SupportScreen.kt
+++ b/app/src/main/java/org/akvo/afribamodkvalidator/ui/screen/SupportScreen.kt
@@ -1,12 +1,16 @@
 package org.akvo.afribamodkvalidator.ui.screen
 
 import android.content.Context
+import android.webkit.WebResourceRequest
 import android.webkit.WebView
+import android.webkit.WebViewClient
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -15,12 +19,19 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.produceState
 import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.viewinterop.AndroidView
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import org.akvo.afribamodkvalidator.ui.theme.AfriBamODKValidatorTheme
 import org.intellij.markdown.flavours.gfm.GFMFlavourDescriptor
 import org.intellij.markdown.html.HtmlGenerator
@@ -35,7 +46,19 @@ fun SupportScreen(
     modifier: Modifier = Modifier
 ) {
     val context = LocalContext.current
-    val html = remember { buildHtml(context) }
+    val isDark = isSystemInDarkTheme()
+    val htmlState = produceState<String?>(initialValue = null, isDark) {
+        value = withContext(Dispatchers.Default) {
+            buildHtml(context, isDark)
+        }
+    }
+    val webViewRef = remember { mutableStateOf<WebView?>(null) }
+
+    DisposableEffect(Unit) {
+        onDispose {
+            webViewRef.value?.destroy()
+        }
+    }
 
     Scaffold(
         topBar = {
@@ -59,51 +82,82 @@ fun SupportScreen(
                 windowInsets = WindowInsets(0)
             )
         },
+        contentWindowInsets = WindowInsets(0, 0, 0, 0),
         modifier = modifier
     ) { innerPadding ->
-        AndroidView(
-            factory = { ctx ->
-                WebView(ctx).apply {
-                    settings.javaScriptEnabled = false
-                    setBackgroundColor(0)
-                    loadDataWithBaseURL(
-                        null, html, "text/html", "UTF-8", null
-                    )
-                }
-            },
-            modifier = Modifier
-                .fillMaxSize()
-                .padding(innerPadding)
-        )
+        val html = htmlState.value
+        if (html == null) {
+            Box(
+                contentAlignment = Alignment.Center,
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(innerPadding)
+            ) {
+                CircularProgressIndicator()
+            }
+        } else {
+            AndroidView(
+                factory = { ctx ->
+                    WebView(ctx).apply {
+                        webViewRef.value = this
+                        settings.javaScriptEnabled = false
+                        settings.allowFileAccess = false
+                        settings.allowContentAccess = false
+                        settings.blockNetworkLoads = true
+                        setBackgroundColor(0)
+                        webViewClient = object : WebViewClient() {
+                            override fun shouldOverrideUrlLoading(
+                                view: WebView?,
+                                request: WebResourceRequest?
+                            ): Boolean = true
+                        }
+                        loadDataWithBaseURL(
+                            null, html, "text/html", "UTF-8", null
+                        )
+                    }
+                },
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(innerPadding)
+            )
+        }
     }
 }
 
-private fun buildHtml(context: Context): String {
+private fun buildHtml(context: Context, isDark: Boolean): String {
     val markdown = loadMarkdownFromAssets(context)
     val flavour = GFMFlavourDescriptor()
-    val tree = MarkdownParser(flavour).buildMarkdownTreeFromString(markdown)
-    val body = HtmlGenerator(markdown, tree, flavour).generateHtml()
-    return wrapWithStyle(body)
+    val tree = MarkdownParser(flavour)
+        .buildMarkdownTreeFromString(markdown)
+    val body = HtmlGenerator(markdown, tree, flavour)
+        .generateHtml()
+    return wrapWithStyle(body, isDark)
 }
 
-private fun wrapWithStyle(body: String): String = """
+private fun wrapWithStyle(body: String, isDark: Boolean): String {
+    val textColor = if (isDark) "#e0e0e0" else "#1a1a1a"
+    val headingColor = if (isDark) "#ffffff" else "#111111"
+    val borderColor = if (isDark) "#444" else "#ccc"
+    val thBg = if (isDark) "#2a2a2a" else "#f0f0f0"
+    val thColor = if (isDark) "#ffffff" else "#1a1a1a"
+    val evenRowBg = if (isDark) "#1e1e1e" else "#f8f8f8"
+    val cellColor = if (isDark) "#e0e0e0" else "#1a1a1a"
+    return """
 <!DOCTYPE html>
 <html>
 <head>
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <style>
-  :root {
-    color-scheme: light dark;
-  }
   body {
     font-family: -apple-system, sans-serif;
     font-size: 15px;
     line-height: 1.5;
     padding: 8px 12px;
     margin: 0;
-    color: #1a1a1a;
+    color: $textColor;
     background: transparent;
   }
+  h1, h2, h3 { color: $headingColor; }
   h1 { font-size: 1.4em; margin: 0.8em 0 0.4em; }
   h2 { font-size: 1.25em; margin: 0.7em 0 0.3em; }
   h3 { font-size: 1.1em; margin: 0.6em 0 0.3em; }
@@ -114,22 +168,17 @@ private fun wrapWithStyle(body: String): String = """
     font-size: 0.92em;
   }
   th, td {
-    border: 1px solid #ccc;
+    border: 1px solid $borderColor;
     padding: 6px 8px;
     text-align: left;
+    color: $cellColor;
   }
   th {
-    background: #f0f0f0;
+    background: $thBg;
+    color: $thColor;
     font-weight: 600;
   }
-  tr:nth-child(even) { background: #f8f8f8; }
-  @media (prefers-color-scheme: dark) {
-    body { color: #e0e0e0; }
-    th { background: #2a2a2a; }
-    td { border-color: #444; }
-    tr:nth-child(even) { background: #1e1e1e; }
-    tr:nth-child(odd)  { background: transparent; }
-  }
+  tr:nth-child(even) { background: $evenRowBg; }
 </style>
 </head>
 <body>
@@ -137,6 +186,7 @@ $body
 </body>
 </html>
 """.trimIndent()
+}
 
 private fun loadMarkdownFromAssets(context: Context): String {
     return try {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -36,6 +36,7 @@ mlkitTextRecognition = "16.0.1"
 datastorePreferences = "1.1.1"
 exifinterface = "1.3.7"
 coroutinesPlayServices = "1.8.1"
+jetbrainsMarkdown = "0.7.3"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -85,6 +86,7 @@ mlkit-text-recognition = { group = "com.google.mlkit", name = "text-recognition"
 datastore-preferences = { group = "androidx.datastore", name = "datastore-preferences", version.ref = "datastorePreferences" }
 exifinterface = { group = "androidx.exifinterface", name = "exifinterface", version.ref = "exifinterface" }
 kotlinx-coroutines-play-services = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-play-services", version.ref = "coroutinesPlayServices" }
+jetbrains-markdown = { module = "org.jetbrains:markdown", version.ref = "jetbrainsMarkdown" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
## Summary

Add a Support screen that renders validation rules documentation from a shared markdown source. The markdown is downloaded at build time from the DCU dashboard repo (single source of truth), converted to HTML via `org.jetbrains:markdown`, and displayed in a WebView with styled tables and dark mode support.

## Key Design Decisions

- **WebView over Compose Markdown**: The mikepenz `multiplatform-markdown-renderer-m3` library has no GFM table support in any released version. WebView natively handles tables, headings, and all HTML elements.
- **Build-time download with offline fallback**: Gradle task `downloadSupportContent` fetches `validation-rules.md` from the DCU repo at build time. If download fails and a cached copy exists, it keeps the existing file; otherwise writes a placeholder.
- **Single source of truth**: Both the DCU Dashboard and this ODK app consume the same `validation-rules.md` from `frontend/public/docs/`, ensuring consistent documentation across platforms.
- **jetbrains-markdown GFM flavour**: Uses `GFMFlavourDescriptor` to parse GitHub-Flavored Markdown including tables, then generates HTML with `HtmlGenerator`.
- **CSS dark mode**: `@media (prefers-color-scheme: dark)` in the HTML template matches the app's dark theme automatically.

## Changes

### Modified: gradle/libs.versions.toml
- Added `jetbrainsMarkdown = "0.7.3"` version and `jetbrains-markdown` library entry
- Removed mikepenz `composeMarkdown` version and library entry

### Modified: app/build.gradle.kts
- Added `downloadSupportContent` Gradle task that fetches markdown from DCU repo
- Wired task to `merge*Assets` so content is always fresh at build time
- Added `jetbrains-markdown` dependency (replaces mikepenz renderer)
- Added `supportContentUrl` project property for CI override

### Modified: app/.gitignore
- Added `src/main/assets/validation-rules.md` (generated at build time)

### New: ui/screen/SupportScreen.kt
- Loads `validation-rules.md` from assets
- Converts markdown to HTML using `MarkdownParser` + `HtmlGenerator` (GFM flavour)
- Wraps HTML in styled template with CSS for headings, bordered tables, alternating rows, dark mode
- Renders via `AndroidView { WebView }` with `loadDataWithBaseURL`

### Modified: navigation/Routes.kt
- Added `Support` route object

### Modified: navigation/AppNavHost.kt
- Added `Support` composable destination wired to `SupportScreen`

### Modified: ui/screen/HomeDashboardScreen.kt
- Added "Support" menu item in overflow menu (above Logout)
- Wired `onSupportClick` callback through composable hierarchy

## Files Changed

| File | Change |
|------|--------|
| `gradle/libs.versions.toml` | Modified -- jetbrains-markdown replaces mikepenz |
| `app/build.gradle.kts` | Modified -- download task + dependency swap |
| `app/.gitignore` | Modified -- ignore generated asset |
| `ui/screen/SupportScreen.kt` | New -- WebView markdown rendering |
| `navigation/Routes.kt` | Modified -- Support route |
| `navigation/AppNavHost.kt` | Modified -- Support destination |
| `ui/screen/HomeDashboardScreen.kt` | Modified -- Support menu item |

## Test Plan

- [ ] `./gradlew assembleDebug` builds successfully
- [ ] Support screen shows validation rules with properly rendered tables
- [ ] Headings are reasonable size (not display-large)
- [ ] Tables have borders, padding, and alternating row colors
- [ ] Dark mode renders correctly (white text, dark table backgrounds)
- [ ] Offline build uses cached `validation-rules.md` if download fails
- [ ] Back button returns to HomeDashboard

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1213432256738100